### PR TITLE
img.defaultuserpic relative path

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -305,7 +305,7 @@ font-size:1.2em;
 
 
 img.defaultuserpic {
-content:url("/user/pix.php?file=/164/f1.jpg");
+content:url("../user/pix.php?file=/164/f1.jpg");
 border: 1px solid #fff;
 margin:0
 }


### PR DESCRIPTION
Change img.defaultuserpic url to a relative path. Fixes broken default profile images when the Moodle site is hosted in a subdirectory.
